### PR TITLE
windows_path connvert posix_path

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 import base64
 import gzip
+import os
 from pathlib import Path
+
+is_Windows = True if os.name == "nt" else False
 
 
 def encode_file(path: Path) -> str:
@@ -10,8 +13,13 @@ def encode_file(path: Path) -> str:
 
 
 def build_script():
-    to_encode = list(Path('easy_gold').glob('*.py')) + [Path('setup.py')]
-    file_data = {str(path): encode_file(path) for path in to_encode}
+    to_encode = list(Path('titanic_sample').glob('*.py')) + [Path('setup.py')]
+    if is_Windows:
+        # https://stackoverflow.com/questions/54671385/convert-windowspath-to-posixpath
+        file_data = {str(path.as_posix()): encode_file(path) for path in
+                     to_encode}
+    else:
+        file_data = {str(path): encode_file(path) for path in to_encode}
     template = Path('script_template.py').read_text('utf8')
     Path('build/script.py').write_text(
         template.replace('{file_data}', str(file_data)),


### PR DESCRIPTION
When the development environment is Windows OS, it is forcibly converted to PosixPath.

e.g.
PosixPath -> hoge/main.py
WindowsPath -> hoge\\main.py

reference: https://stackoverflow.com/questions/54671385/convert-windowspath-to-posixpath